### PR TITLE
Use core 2.28.0

### DIFF
--- a/update_ucrt_only.sh
+++ b/update_ucrt_only.sh
@@ -9,9 +9,9 @@ set -x
 ##
 ## And now also updated for 'ucrt' builds
 ##
-for f in mingw-w64-ucrt64-tiledb.zip; do
+for f in release-windows-x86_64-mingw64_ucrt64-release-2.28-4764907.zip; do
 #for f in mingw-w64-MINGW32-tiledb.zip mingw-w64-MINGW64-tiledb.zip mingw-w64-ucrt64-tiledb.zip; do
-    mv -v ~/Downloads/${f} .
+    cp ~/Downloads/${f} .
     unzip ${f}
     rm ${f}
 done


### PR DESCRIPTION
Same as #2 -- following https://www.notion.so/Release-process-for-TileDB-R-11332650117580b79eece5ccff0e3e5f -- since the core 2.28.0-rc0 and 2.28.0 tags are on the same core Git hash.

https://linear.app/tiledb/issue/CORE-68/update-projects-to-tiledb-228